### PR TITLE
add a wrap data method

### DIFF
--- a/src/JSend/JSendResponse.php
+++ b/src/JSend/JSendResponse.php
@@ -103,7 +103,7 @@ class JSendResponse
      * Wrap the data with the Jsend specifications
      * @return array to encode
      */
-    public function wrap()
+    public function asArray()
     {
         $toEncode = array(
             'status' => $this->status,
@@ -136,7 +136,7 @@ class JSendResponse
      */
     public function encode()
     {
-        return json_encode($this->wrap());
+        return json_encode($this->asArray());
     }
 
     /**


### PR DESCRIPTION
Hi,
Adding a wrap method allows to prepare the jsend data but not force the encoding in json, in case you want to make the json encoding by a third party.

Of course the encode shortcut method still exists ;)

(I didn't make the tests update, i'm making a little pull request from github website)
