### PR TITLE
Small change to return type of jsonSerialize()

### DIFF
--- a/src/JSend/JSendResponse.php
+++ b/src/JSend/JSendResponse.php
@@ -204,9 +204,9 @@ class JSendResponse implements JsonSerializable
 
     /**
      * Implements JsonSerializable interface
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
         return $this->asArray();
     }


### PR DESCRIPTION
Change the return type of jsonSerialize to match the base implementation (https://www.php.net/manual/en/jsonserializable.jsonserialize.php). With array as the return type PHP sends a Notice, which can lead to unparsable JSON output.